### PR TITLE
Schema Registration - Allow Specification from File Path

### DIFF
--- a/examples/notebooks/custom-metadata/custom_metadata.ipynb
+++ b/examples/notebooks/custom-metadata/custom_metadata.ipynb
@@ -21,15 +21,9 @@
         "\n",
         "client = Client()\n",
         "# Register schemas\n",
-        "with open(\"cable_schema.toml\", \"r\", encoding=\"utf-8\") as f:\n",
-        "    cable_schema = f.read()\n",
-        "cable_schema_id = client.register_schema(cable_schema)\n",
-        "with open(\"socket_schema.toml\", \"r\", encoding=\"utf-8\") as f:\n",
-        "    socket_schema = f.read()\n",
-        "socket_schema_id = client.register_schema(socket_schema)\n",
-        "with open(\"scope_schema.toml\", \"r\", encoding=\"utf-8\") as f:\n",
-        "    scope_schema = f.read()\n",
-        "scope_schema_id = client.register_schema(scope_schema)"
+        "cable_schema_id = client.register_schema(\"cable_schema.toml\")\n",
+        "socket_schema_id = client.register_schema(\"socket_schema.toml\")\n",
+        "scope_schema_id = client.register_schema(\"scope_schema.toml\")"
       ]
     },
     {
@@ -95,9 +89,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "with open(\"test_result_schema.toml\", \"r\", encoding=\"utf-8\") as f:\n",
-        "    test_result_schema = f.read()\n",
-        "test_result_schema_id = client.register_schema(test_result_schema)"
+        "test_result_schema_id = client.register_schema(\"test_result_schema.toml\")"
       ]
     },
     {

--- a/examples/notebooks/overview/publish_measurement.ipynb
+++ b/examples/notebooks/overview/publish_measurement.ipynb
@@ -20,9 +20,7 @@
     "from ni.datastore import Client\n",
     "\n",
     "client = Client()\n",
-    "with open(\"sample_schema.json\", \"r\", encoding=\"utf-8\") as f:\n",
-    "    contents = f.read()\n",
-    "schema_id = client.register_schema(contents)\n",
+    "schema_id = client.register_schema(\"sample_schema.json\")\n",
     "print(f\"registered schema id: {schema_id}\")"
    ]
   },

--- a/tests/assets/unit/schemas/hardware_item_schema.toml
+++ b/tests/assets/unit/schemas/hardware_item_schema.toml
@@ -1,0 +1,4 @@
+id = "https://example.com/hardware.item.schema.toml"
+
+[hardware_item]
+cable_length = "*"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import NonCallableMock
 
@@ -52,3 +53,15 @@ def mocked_moniker_client(mocker: MockerFixture) -> Any:
     mock_moniker_client = mocker.patch("ni.datamonikers.v1.client.MonikerClient", autospec=True)
     mock_moniker_instance = mock_moniker_client.return_value
     return mock_moniker_instance
+
+
+@pytest.fixture(scope="module")
+def schemas_directory(test_assets_directory: Path) -> Path:
+    """Returns the test assets directory containing schemas."""
+    return test_assets_directory / "unit" / "schemas"
+
+
+@pytest.fixture(scope="module")
+def test_assets_directory() -> Path:
+    """Returns the test assets directory."""
+    return Path(__file__).parent.parent / "assets"

--- a/tests/unit/test_register_schema.py
+++ b/tests/unit/test_register_schema.py
@@ -1,0 +1,62 @@
+"""Contains tests for validating schema registration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import NonCallableMock
+
+from ni.datastore import (
+    Client,
+)
+from ni.measurements.metadata.v1.metadata_store_service_pb2 import (
+    RegisterSchemaRequest,
+)
+
+
+def test___register_schema_from_path____calls_metadatastoreclient_with_file_contents(
+    client: Client, mocked_metadatastore_client: NonCallableMock, schemas_directory: Path
+) -> None:
+    schema_path = schemas_directory / "hardware_item_schema.toml"
+
+    client.register_schema(schema_path)
+
+    args, __ = mocked_metadatastore_client.register_schema.call_args
+    request = cast(RegisterSchemaRequest, args[0])
+    assert request.schema == schema_path.read_text()
+
+
+def test___register_schema_from_string_path____calls_metadatastoreclient_with_file_contents(
+    client: Client, mocked_metadatastore_client: NonCallableMock, schemas_directory: Path
+) -> None:
+    schema_path = schemas_directory / "hardware_item_schema.toml"
+
+    client.register_schema(str(schema_path))
+
+    args, __ = mocked_metadatastore_client.register_schema.call_args
+    request = cast(RegisterSchemaRequest, args[0])
+    assert request.schema == schema_path.read_text()
+
+
+def test___register_schema_from_schema_contents____calls_metadatastoreclient_with_schema_contents(
+    client: Client, mocked_metadatastore_client: NonCallableMock, schemas_directory: Path
+) -> None:
+    schema_path = schemas_directory / "hardware_item_schema.toml"
+
+    client.register_schema(schema_path.read_text())
+
+    args, __ = mocked_metadatastore_client.register_schema.call_args
+    request = cast(RegisterSchemaRequest, args[0])
+    assert request.schema == schema_path.read_text()
+
+
+def test___register_schema___returns_schema_id_from_metadatastoreclient(
+    client: Client, mocked_metadatastore_client: NonCallableMock, schemas_directory: Path
+) -> None:
+    schema_path = schemas_directory / "hardware_item_schema.toml"
+    expected_schema_id = "schema_id_123"
+    mocked_metadatastore_client.register_schema.return_value.schema_id = expected_schema_id
+
+    schema_id = client.register_schema(schema_path)
+
+    assert schema_id == expected_schema_id


### PR DESCRIPTION
### What does this Pull Request accomplish?

This set of changes adds support to the existing `register_schema` method in the client API for specifying the _path_ to a given schema in the file system, in addition to the existing support for directly supplying the contents of the schema itself.

For flexibilty, the `register_schema` method now supports specifying the file path as either a `str` or `pathlib.Path`.

### Why should this Pull Request be merged?

This additional functionality helps streamline the use case in which the client has a schema file saved on disk and wishes to register it with the service. As can be seen in the changes in this PR to the example notebooks, this code becomes less verbose.

### What testing has been done?

- Added new tests verifying that the contents of the specified schema file are passed to the service
- Existing automated tests pass
- Existing notebooks and examples still function as expected