### PR TITLE
Implement batch publishing for basic iterables

### DIFF
--- a/src/ni/datastore/grpc_conversion.py
+++ b/src/ni/datastore/grpc_conversion.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import MutableMapping
+from typing import Iterable, MutableMapping
 
 import numpy as np
 from google.protobuf.any_pb2 import Any
@@ -73,9 +73,19 @@ def populate_publish_condition_batch_request_values(
     publish_request: PublishConditionBatchRequest, values: object
 ) -> None:
     """Assign a value to the scalar_values vector member of PublishConditionBatchRequest."""
-    # TODO: Determine whether we wish to support primitive types such as a list of float
     if isinstance(values, Vector):
         publish_request.scalar_values.CopyFrom(vector_to_protobuf(values))
+    elif isinstance(values, Iterable):
+        if not values:
+            raise ValueError("Cannot publish an empty Iterable.")
+        try:
+            vector = Vector(values)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Unsupported iterable: {values}. Subtype must be bool, float, int, or string."
+            )
+
+        publish_request.scalar_values.CopyFrom(vector_to_protobuf(vector))
     else:
         raise TypeError(
             f"Unsupported condition values type: {type(values)}. Please consult the documentation."
@@ -134,9 +144,19 @@ def populate_publish_measurement_batch_request_values(
     publish_request: PublishMeasurementBatchRequest, values: object
 ) -> None:
     """Assign a value to the appropriate field of the PublishMeasurementBatchRequest object."""
-    # TODO: Determine whether we wish to support primitive types such as a list of float
     if isinstance(values, Vector):
         publish_request.scalar_values.CopyFrom(vector_to_protobuf(values))
+    elif isinstance(values, Iterable):
+        if not values:
+            raise ValueError("Cannot publish an empty Iterable.")
+        try:
+            vector = Vector(values)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Unsupported iterable: {values}. Subtype must be bool, float, int, or string."
+            )
+
+        publish_request.scalar_values.CopyFrom(vector_to_protobuf(vector))
     else:
         raise TypeError(
             f"Unsupported measurement values type: {type(values)}. Please consult the documentation."

--- a/tests/unit/test_publish_condition.py
+++ b/tests/unit/test_publish_condition.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import pytest
 from typing import cast
 from unittest.mock import NonCallableMock
 
+import pytest
 from ni.datastore import Client
 from ni.measurements.data.v1.data_store_pb2 import PublishedCondition
 from ni.measurements.data.v1.data_store_service_pb2 import (

--- a/tests/unit/test_publish_condition.py
+++ b/tests/unit/test_publish_condition.py
@@ -41,6 +41,20 @@ def test___publish_condition___calls_datastoreclient(
     assert request.scalar.sint32_value == 123
 
 
+def test___none___publish_condition___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_condition(
+            condition_name="TestCondition",
+            type="ConditionType",
+            value=None,
+            step_id="MyStep",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported condition value type")
+
+
 def test___vector___publish_condition_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
@@ -180,3 +194,17 @@ def test___empty_list___publish_condition_batch___raises_value_error(
         )
 
     assert exc.value.args[0].startswith("Cannot publish an empty Iterable.")
+
+
+def test___none___publish_condition_batch___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_condition_batch(
+            condition_name="TestCondition",
+            type="ConditionType",
+            values=None,
+            step_id="MyStep",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported condition values type")

--- a/tests/unit/test_publish_condition.py
+++ b/tests/unit/test_publish_condition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from typing import cast
 from unittest.mock import NonCallableMock
 
@@ -40,7 +41,7 @@ def test___publish_condition___calls_datastoreclient(
     assert request.scalar.sint32_value == 123
 
 
-def test___publish_condition_batch___calls_datastoreclient(
+def test___vector___publish_condition_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -63,3 +64,119 @@ def test___publish_condition_batch___calls_datastoreclient(
     assert request.type == "ConditionType"
     assert list(request.scalar_values.string_array.values) == ["one", "two", "three"]
     assert request.scalar_values.attributes["NI_UnitDescription"].string_value == "fake_units"
+
+
+def test___int_list___publish_condition_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    published_condition = PublishedCondition(published_condition_id="response_id")
+    expected_response = PublishConditionBatchResponse(published_condition=published_condition)
+    mocked_datastore_client.publish_condition_batch.return_value = expected_response
+
+    result = client.publish_condition_batch(
+        condition_name="TestCondition",
+        type="ConditionType",
+        values=[1, 2, 3],
+        step_id="MyStep",
+    )
+
+    args, __ = mocked_datastore_client.publish_condition_batch.call_args
+    request = cast(PublishConditionBatchRequest, args[0])
+    assert result.published_condition_id == "response_id"
+    assert list(request.scalar_values.sint32_array.values) == [1, 2, 3]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___float_list___publish_condition_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    published_condition = PublishedCondition(published_condition_id="response_id")
+    expected_response = PublishConditionBatchResponse(published_condition=published_condition)
+    mocked_datastore_client.publish_condition_batch.return_value = expected_response
+
+    result = client.publish_condition_batch(
+        condition_name="TestCondition",
+        type="ConditionType",
+        values=[1.0, 2.0, 3.0],
+        step_id="MyStep",
+    )
+
+    args, __ = mocked_datastore_client.publish_condition_batch.call_args
+    request = cast(PublishConditionBatchRequest, args[0])
+    assert result.published_condition_id == "response_id"
+    assert list(request.scalar_values.double_array.values) == [1.0, 2.0, 3.0]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___bool_list___publish_condition_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    published_condition = PublishedCondition(published_condition_id="response_id")
+    expected_response = PublishConditionBatchResponse(published_condition=published_condition)
+    mocked_datastore_client.publish_condition_batch.return_value = expected_response
+
+    result = client.publish_condition_batch(
+        condition_name="TestCondition",
+        type="ConditionType",
+        values=[True, False, True],
+        step_id="MyStep",
+    )
+
+    args, __ = mocked_datastore_client.publish_condition_batch.call_args
+    request = cast(PublishConditionBatchRequest, args[0])
+    assert result.published_condition_id == "response_id"
+    assert list(request.scalar_values.bool_array.values) == [True, False, True]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___string_list___publish_condition_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    published_condition = PublishedCondition(published_condition_id="response_id")
+    expected_response = PublishConditionBatchResponse(published_condition=published_condition)
+    mocked_datastore_client.publish_condition_batch.return_value = expected_response
+
+    result = client.publish_condition_batch(
+        condition_name="TestCondition",
+        type="ConditionType",
+        values=["one", "two", "three"],
+        step_id="MyStep",
+    )
+
+    args, __ = mocked_datastore_client.publish_condition_batch.call_args
+    request = cast(PublishConditionBatchRequest, args[0])
+    assert result.published_condition_id == "response_id"
+    assert list(request.scalar_values.string_array.values) == ["one", "two", "three"]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___unsupported_list___publish_condition_batch___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_condition_batch(
+            condition_name="TestCondition",
+            type="ConditionType",
+            values=[[1, 2, 3], [4, 5, 6]],  # List of lists will error during vector creation.
+            step_id="MyStep",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported iterable:")
+
+
+def test___empty_list___publish_condition_batch___raises_value_error(
+    client: Client,
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        _ = client.publish_condition_batch(
+            condition_name="TestCondition",
+            type="ConditionType",
+            values=[],
+            step_id="MyStep",
+        )
+
+    assert exc.value.args[0].startswith("Cannot publish an empty Iterable.")

--- a/tests/unit/test_publish_measurement.py
+++ b/tests/unit/test_publish_measurement.py
@@ -175,7 +175,7 @@ def test___publish_analog_waveform_data_with_mismatched_timestamp_parameter___ra
         client.publish_measurement("name", analog_waveform, "step_id", mismatched_timestamp)
 
 
-def test___publish_measurement_batch___calls_datastoreclient(
+def test___vector___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -211,3 +211,135 @@ def test___publish_measurement_batch___calls_datastoreclient(
     assert request.hardware_item_ids == []
     assert request.software_item_ids == []
     assert request.test_adapter_ids == []
+
+
+def test___int_sequence___publish_measurement_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    timestamp = datetime.now(tz=std_datetime.timezone.utc)
+    published_measurement = PublishedMeasurement(published_measurement_id="response_id")
+    expected_response = PublishMeasurementBatchResponse(
+        published_measurements=[published_measurement]
+    )
+    mocked_datastore_client.publish_measurement_batch.return_value = expected_response
+
+    response = client.publish_measurement_batch(
+        measurement_name="name",
+        values=[1, 2, 3],
+        step_id="step_id",
+        timestamps=[timestamp],
+        outcomes=[Outcome.OUTCOME_PASSED],
+        error_information=[ErrorInformation()],
+        hardware_item_ids=[],
+        test_adapter_ids=[],
+        software_item_ids=[],
+    )
+
+    args, __ = mocked_datastore_client.publish_measurement_batch.call_args
+    request = cast(PublishMeasurementBatchRequest, args[0])
+    assert next(iter(response)).published_measurement_id == "response_id"
+    assert request.step_id == "step_id"
+    assert request.measurement_name == "name"
+    assert request.timestamp == [hightime_datetime_to_protobuf(timestamp)]
+    assert request.scalar_values.sint32_array.values == [1, 2, 3]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___float_sequence___publish_measurement_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    timestamp = datetime.now(tz=std_datetime.timezone.utc)
+    published_measurement = PublishedMeasurement(published_measurement_id="response_id")
+    expected_response = PublishMeasurementBatchResponse(
+        published_measurements=[published_measurement]
+    )
+    mocked_datastore_client.publish_measurement_batch.return_value = expected_response
+
+    response = client.publish_measurement_batch(
+        measurement_name="name",
+        values=[1.0, 2.0, 3.0],
+        step_id="step_id",
+        timestamps=[timestamp],
+        outcomes=[Outcome.OUTCOME_PASSED],
+        error_information=[ErrorInformation()],
+        hardware_item_ids=[],
+        test_adapter_ids=[],
+        software_item_ids=[],
+    )
+
+    args, __ = mocked_datastore_client.publish_measurement_batch.call_args
+    request = cast(PublishMeasurementBatchRequest, args[0])
+    assert next(iter(response)).published_measurement_id == "response_id"
+    assert request.step_id == "step_id"
+    assert request.measurement_name == "name"
+    assert request.timestamp == [hightime_datetime_to_protobuf(timestamp)]
+    assert request.scalar_values.double_array.values == [1.0, 2.0, 3.0]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___bool_sequence___publish_measurement_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    timestamp = datetime.now(tz=std_datetime.timezone.utc)
+    published_measurement = PublishedMeasurement(published_measurement_id="response_id")
+    expected_response = PublishMeasurementBatchResponse(
+        published_measurements=[published_measurement]
+    )
+    mocked_datastore_client.publish_measurement_batch.return_value = expected_response
+
+    response = client.publish_measurement_batch(
+        measurement_name="name",
+        values=[True, False, True],
+        step_id="step_id",
+        timestamps=[timestamp],
+        outcomes=[Outcome.OUTCOME_PASSED],
+        error_information=[ErrorInformation()],
+        hardware_item_ids=[],
+        test_adapter_ids=[],
+        software_item_ids=[],
+    )
+
+    args, __ = mocked_datastore_client.publish_measurement_batch.call_args
+    request = cast(PublishMeasurementBatchRequest, args[0])
+    assert next(iter(response)).published_measurement_id == "response_id"
+    assert request.step_id == "step_id"
+    assert request.measurement_name == "name"
+    assert request.timestamp == [hightime_datetime_to_protobuf(timestamp)]
+    assert request.scalar_values.bool_array.values == [True, False, True]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___str_sequence___publish_measurement_batch___calls_datastoreclient(
+    client: Client,
+    mocked_datastore_client: NonCallableMock,
+) -> None:
+    timestamp = datetime.now(tz=std_datetime.timezone.utc)
+    published_measurement = PublishedMeasurement(published_measurement_id="response_id")
+    expected_response = PublishMeasurementBatchResponse(
+        published_measurements=[published_measurement]
+    )
+    mocked_datastore_client.publish_measurement_batch.return_value = expected_response
+
+    response = client.publish_measurement_batch(
+        measurement_name="name",
+        values=["one", "two", "three"],
+        step_id="step_id",
+        timestamps=[timestamp],
+        outcomes=[Outcome.OUTCOME_PASSED],
+        error_information=[ErrorInformation()],
+        hardware_item_ids=[],
+        test_adapter_ids=[],
+        software_item_ids=[],
+    )
+
+    args, __ = mocked_datastore_client.publish_measurement_batch.call_args
+    request = cast(PublishMeasurementBatchRequest, args[0])
+    assert next(iter(response)).published_measurement_id == "response_id"
+    assert request.step_id == "step_id"
+    assert request.measurement_name == "name"
+    assert request.timestamp == [hightime_datetime_to_protobuf(timestamp)]
+    assert request.scalar_values.string_array.values == ["one", "two", "three"]
+    assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""

--- a/tests/unit/test_publish_measurement.py
+++ b/tests/unit/test_publish_measurement.py
@@ -175,6 +175,19 @@ def test___publish_analog_waveform_data_with_mismatched_timestamp_parameter___ra
         client.publish_measurement("name", analog_waveform, "step_id", mismatched_timestamp)
 
 
+def test___none___publish_measurement___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_measurement(
+            measurement_name="name",
+            value=None,
+            step_id="step_id",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported measurement value type")
+
+
 def test___vector___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
@@ -369,3 +382,16 @@ def test___empty_list___publish_measurement_batch___raises_type_error(
         )
 
     assert exc.value.args[0].startswith("Cannot publish an empty Iterable.")
+
+
+def test___none___publish_measurement_batch___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_measurement_batch(
+            measurement_name="name",
+            values=None,
+            step_id="step_id",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported measurement values type")

--- a/tests/unit/test_publish_measurement.py
+++ b/tests/unit/test_publish_measurement.py
@@ -213,7 +213,7 @@ def test___vector___publish_measurement_batch___calls_datastoreclient(
     assert request.test_adapter_ids == []
 
 
-def test___int_sequence___publish_measurement_batch___calls_datastoreclient(
+def test___int_list___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -246,7 +246,7 @@ def test___int_sequence___publish_measurement_batch___calls_datastoreclient(
     assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
 
 
-def test___float_sequence___publish_measurement_batch___calls_datastoreclient(
+def test___float_list___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -279,7 +279,7 @@ def test___float_sequence___publish_measurement_batch___calls_datastoreclient(
     assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
 
 
-def test___bool_sequence___publish_measurement_batch___calls_datastoreclient(
+def test___bool_list___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -312,7 +312,7 @@ def test___bool_sequence___publish_measurement_batch___calls_datastoreclient(
     assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
 
 
-def test___str_sequence___publish_measurement_batch___calls_datastoreclient(
+def test___str_list___publish_measurement_batch___calls_datastoreclient(
     client: Client,
     mocked_datastore_client: NonCallableMock,
 ) -> None:
@@ -343,3 +343,29 @@ def test___str_sequence___publish_measurement_batch___calls_datastoreclient(
     assert request.timestamp == [hightime_datetime_to_protobuf(timestamp)]
     assert request.scalar_values.string_array.values == ["one", "two", "three"]
     assert request.scalar_values.attributes["NI_UnitDescription"].string_value == ""
+
+
+def test___unsupported_list___publish_measurement_batch___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = client.publish_measurement_batch(
+            measurement_name="name",
+            values=[[1, 2, 3], [4, 5, 6]],  # List of lists will error during vector creation.
+            step_id="step_id",
+        )
+
+    assert exc.value.args[0].startswith("Unsupported iterable:")
+
+
+def test___empty_list___publish_measurement_batch___raises_type_error(
+    client: Client,
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        _ = client.publish_measurement_batch(
+            measurement_name="name",
+            values=[],
+            step_id="step_id",
+        )
+
+    assert exc.value.args[0].startswith("Cannot publish an empty Iterable.")


### PR DESCRIPTION
### What does this Pull Request accomplish?

Allow users to pass basic `Iterable` objects to `publish_measurement_batch` and `publish_condition_batch`. The only supported subtypes are the types that are supported by the `Vector` class: `bool`, `float`, `int`, `str`. We are converting to a `VectorProto` by first creating a `nitypes.vector.Vector` and calling `vector_to_protobuf()`.

### Why should this Pull Request be merged?

[AB#3353538](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3353538)

### What testing has been done?

I added new unit tests to verify the supported iterable types. I also added a couple of unit tests to cover the error cases.