### PR TITLE
Add basic iterable support to publish_measurement

### DIFF
--- a/src/ni/datastore/data/_grpc_conversion.py
+++ b/src/ni/datastore/data/_grpc_conversion.py
@@ -137,6 +137,17 @@ def populate_publish_measurement_request_value(
             raise TypeError(f"Unsupported Spectrum dtype: {value.dtype}")
     elif isinstance(value, DigitalWaveform):
         publish_request.digital_waveform.CopyFrom(digital_waveform_to_protobuf(value))
+    elif isinstance(value, Iterable):
+        if not value:
+            raise ValueError("Cannot publish an empty Iterable.")
+        try:
+            vector = Vector(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Unsupported iterable: {value}. Subtype must be bool, float, int, or string."
+            )
+
+        publish_request.vector.CopyFrom(vector_to_protobuf(vector))
     else:
         raise TypeError(
             f"Unsupported measurement value type: {type(value)}. Please consult the documentation."


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for users to pass an `Iterable[bool, int, float, str]` to `publish_measurement`. In this case, the iterable data is packaged into a `Vector` protobuf type and assigned to the `PublishRequest`'s `vector` field.

### Why should this Pull Request be merged?

Fixes #35 

### What testing has been done?

I added a unit test that publishes an iterable of these types: int, float, bool, str. The test uses mocks to check the publish request and make sure it is properly packaged into a vector protobuf type.

All unit tests pass. Also mypy, pyright, and styleguide.
