### PR TITLE
Data Store APIs - Clearer and Easier Use of Collections

### DIFF
--- a/src/ni/datastore/data/_data_store_client.py
+++ b/src/ni/datastore/data/_data_store_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from threading import Lock
 from typing import Type, TypeVar, overload
 from urllib.parse import urlparse
@@ -174,7 +174,7 @@ class DataStoreClient:
         hardware_item_ids: Iterable[str] = tuple(),
         test_adapter_ids: Iterable[str] = tuple(),
         software_item_ids: Iterable[str] = tuple(),
-    ) -> Iterable[PublishedMeasurement]:
+    ) -> Sequence[PublishedMeasurement]:
         """Publish a batch of N values of a measurement to the data store."""
         publish_request = PublishMeasurementBatchRequest(
             measurement_name=measurement_name,
@@ -253,7 +253,7 @@ class DataStoreClient:
         get_response = self._get_data_store_client().get_test_result(get_request)
         return TestResult.from_protobuf(get_response.test_result)
 
-    def query_conditions(self, odata_query: str) -> Iterable[PublishedCondition]:
+    def query_conditions(self, odata_query: str = "") -> Sequence[PublishedCondition]:
         """Query conditions from the data store."""
         query_request = QueryConditionsRequest(odata_query=odata_query)
         query_response = self._get_data_store_client().query_conditions(query_request)
@@ -262,7 +262,7 @@ class DataStoreClient:
             for published_condition in query_response.published_conditions
         ]
 
-    def query_measurements(self, odata_query: str) -> Iterable[PublishedMeasurement]:
+    def query_measurements(self, odata_query: str = "") -> Sequence[PublishedMeasurement]:
         """Query measurements from the data store."""
         query_request = QueryMeasurementsRequest(odata_query=odata_query)
         query_response = self._get_data_store_client().query_measurements(query_request)
@@ -271,7 +271,7 @@ class DataStoreClient:
             for published_measurement in query_response.published_measurements
         ]
 
-    def query_steps(self, odata_query: str) -> Iterable[Step]:
+    def query_steps(self, odata_query: str = "") -> Sequence[Step]:
         """Query steps from the data store."""
         query_request = QueryStepsRequest(odata_query=odata_query)
         query_response = self._get_data_store_client().query_steps(query_request)

--- a/src/ni/datastore/data/_types/_published_measurement.py
+++ b/src/ni/datastore/data/_types/_published_measurement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, MutableSequence
 
 import hightime as ht
 from ni.datamonikers.v1.data_moniker_pb2 import Moniker
@@ -23,13 +23,13 @@ class PublishedMeasurement:
 
     __slots__ = (
         "moniker",
-        "published_conditions",
+        "_published_conditions",
         "published_measurement_id",
         "test_result_id",
         "step_id",
-        "software_item_ids",
-        "hardware_item_ids",
-        "test_adapter_ids",
+        "_software_item_ids",
+        "_hardware_item_ids",
+        "_test_adapter_ids",
         "measurement_name",
         "data_type",
         "measurement_notes",
@@ -39,6 +39,26 @@ class PublishedMeasurement:
         "parametric_index",
         "error_information",
     )
+
+    @property
+    def published_conditions(self) -> MutableSequence[PublishedCondition]:
+        """The published conditions associated with the published measurement."""
+        return self._published_conditions
+
+    @property
+    def software_item_ids(self) -> MutableSequence[str]:
+        """The software item IDs associated with the published measurement."""
+        return self._software_item_ids
+
+    @property
+    def hardware_item_ids(self) -> MutableSequence[str]:
+        """The hardware item IDs associated with the published measurement."""
+        return self._hardware_item_ids
+
+    @property
+    def test_adapter_ids(self) -> MutableSequence[str]:
+        """The test adapter IDs associated with the published measurement."""
+        return self._test_adapter_ids
 
     def __init__(
         self,
@@ -62,20 +82,20 @@ class PublishedMeasurement:
     ) -> None:
         """Initialize a PublishedMeasurement instance."""
         self.moniker = moniker
-        self.published_conditions: Iterable[PublishedCondition] = (
-            published_conditions if published_conditions is not None else []
+        self._published_conditions: MutableSequence[PublishedCondition] = (
+            list(published_conditions) if published_conditions is not None else []
         )
         self.published_measurement_id = published_measurement_id
         self.test_result_id = test_result_id
         self.step_id = step_id
-        self.software_item_ids: Iterable[str] = (
-            software_item_ids if software_item_ids is not None else []
+        self._software_item_ids: MutableSequence[str] = (
+            list(software_item_ids) if software_item_ids is not None else []
         )
-        self.hardware_item_ids: Iterable[str] = (
-            hardware_item_ids if hardware_item_ids is not None else []
+        self._hardware_item_ids: MutableSequence[str] = (
+            list(hardware_item_ids) if hardware_item_ids is not None else []
         )
-        self.test_adapter_ids: Iterable[str] = (
-            test_adapter_ids if test_adapter_ids is not None else []
+        self._test_adapter_ids: MutableSequence[str] = (
+            list(test_adapter_ids) if test_adapter_ids is not None else []
         )
         self.measurement_name = measurement_name
         self.data_type = data_type
@@ -166,13 +186,13 @@ class PublishedMeasurement:
             return NotImplemented
         return (
             self.moniker == other.moniker
-            and list(self.published_conditions) == list(other.published_conditions)
+            and self.published_conditions == other.published_conditions
             and self.published_measurement_id == other.published_measurement_id
             and self.test_result_id == other.test_result_id
             and self.step_id == other.step_id
-            and list(self.software_item_ids) == list(other.software_item_ids)
-            and list(self.hardware_item_ids) == list(other.hardware_item_ids)
-            and list(self.test_adapter_ids) == list(other.test_adapter_ids)
+            and self.software_item_ids == other.software_item_ids
+            and self.hardware_item_ids == other.hardware_item_ids
+            and self.test_adapter_ids == other.test_adapter_ids
             and self.measurement_name == other.measurement_name
             and self.data_type == other.data_type
             and self.measurement_notes == other.measurement_notes

--- a/src/ni/datastore/data/_types/_step.py
+++ b/src/ni/datastore/data/_types/_step.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 import hightime as ht
 from ni.datastore.metadata._grpc_conversion import (
@@ -32,7 +32,7 @@ class Step:
         "_start_date_time",
         "_end_date_time",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
 
@@ -46,6 +46,11 @@ class Step:
         """Get the end date and time of the step execution."""
         return self._end_date_time
 
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the step."""
+        return self._extensions
+
     def __init__(
         self,
         *,
@@ -57,7 +62,7 @@ class Step:
         step_type: str = "",
         notes: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a Step instance."""
@@ -69,7 +74,9 @@ class Step:
         self.step_type = step_type
         self.notes = notes
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
         self._start_date_time: ht.datetime | None = None

--- a/src/ni/datastore/data/_types/_test_result.py
+++ b/src/ni/datastore/data/_types/_test_result.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, MutableMapping
+from typing import Iterable, Mapping, MutableMapping, MutableSequence
 
 import hightime as ht
 from ni.datastore.metadata._grpc_conversion import (
@@ -28,15 +28,15 @@ class TestResult:
         "operator_id",
         "test_station_id",
         "test_description_id",
-        "software_item_ids",
-        "hardware_item_ids",
-        "test_adapter_ids",
+        "_software_item_ids",
+        "_hardware_item_ids",
+        "_test_adapter_ids",
         "test_result_name",
         "_start_date_time",
         "_end_date_time",
         "_outcome",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
 
@@ -55,6 +55,26 @@ class TestResult:
         """Get the outcome of the test execution."""
         return self._outcome
 
+    @property
+    def software_item_ids(self) -> MutableSequence[str]:
+        """The software item IDs associated with the test result."""
+        return self._software_item_ids
+
+    @property
+    def hardware_item_ids(self) -> MutableSequence[str]:
+        """The hardware item IDs associated with the test result."""
+        return self._hardware_item_ids
+
+    @property
+    def test_adapter_ids(self) -> MutableSequence[str]:
+        """The test adapter IDs associated with the test result."""
+        return self._test_adapter_ids
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the test result."""
+        return self._extensions
+
     def __init__(
         self,
         *,
@@ -68,7 +88,7 @@ class TestResult:
         test_adapter_ids: Iterable[str] | None = None,
         test_result_name: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a TestResult instance."""
@@ -77,18 +97,20 @@ class TestResult:
         self.operator_id = operator_id
         self.test_station_id = test_station_id
         self.test_description_id = test_description_id
-        self.software_item_ids: Iterable[str] = (
-            software_item_ids if software_item_ids is not None else []
+        self._software_item_ids: MutableSequence[str] = (
+            list(software_item_ids) if software_item_ids is not None else []
         )
-        self.hardware_item_ids: Iterable[str] = (
-            hardware_item_ids if hardware_item_ids is not None else []
+        self._hardware_item_ids: MutableSequence[str] = (
+            list(hardware_item_ids) if hardware_item_ids is not None else []
         )
-        self.test_adapter_ids: Iterable[str] = (
-            test_adapter_ids if test_adapter_ids is not None else []
+        self._test_adapter_ids: MutableSequence[str] = (
+            list(test_adapter_ids) if test_adapter_ids is not None else []
         )
         self.test_result_name = test_result_name
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
         self._start_date_time: ht.datetime | None = None
@@ -164,9 +186,9 @@ class TestResult:
             and self.operator_id == other.operator_id
             and self.test_station_id == other.test_station_id
             and self.test_description_id == other.test_description_id
-            and list(self.software_item_ids) == list(other.software_item_ids)
-            and list(self.hardware_item_ids) == list(other.hardware_item_ids)
-            and list(self.test_adapter_ids) == list(other.test_adapter_ids)
+            and self.software_item_ids == other.software_item_ids
+            and self.hardware_item_ids == other.hardware_item_ids
+            and self.test_adapter_ids == other.test_adapter_ids
             and self.test_result_name == other.test_result_name
             and self.start_date_time == other.start_date_time
             and self.end_date_time == other.end_date_time

--- a/src/ni/datastore/metadata/_metadata_store_client.py
+++ b/src/ni/datastore/metadata/_metadata_store_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Sequence
 from pathlib import Path
 from threading import Lock
 
@@ -113,7 +113,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_uut_instance(get_request)
         return UutInstance.from_protobuf(get_response.uut_instance)
 
-    def query_uut_instances(self, odata_query: str) -> Iterable[UutInstance]:
+    def query_uut_instances(self, odata_query: str = "") -> Sequence[UutInstance]:
         """Query UUT instances from the metadata store."""
         query_request = QueryUutInstancesRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_uut_instances(query_request)
@@ -133,7 +133,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_uut(get_request)
         return Uut.from_protobuf(get_response.uut)
 
-    def query_uuts(self, odata_query: str) -> Iterable[Uut]:
+    def query_uuts(self, odata_query: str = "") -> Sequence[Uut]:
         """Query UUTs from the metadata store."""
         query_request = QueryUutsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_uuts(query_request)
@@ -151,7 +151,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_operator(get_request)
         return Operator.from_protobuf(get_response.operator)
 
-    def query_operators(self, odata_query: str) -> Iterable[Operator]:
+    def query_operators(self, odata_query: str = "") -> Sequence[Operator]:
         """Query operators from the metadata store."""
         query_request = QueryOperatorsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_operators(query_request)
@@ -171,7 +171,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_test_description(get_request)
         return TestDescription.from_protobuf(get_response.test_description)
 
-    def query_test_descriptions(self, odata_query: str) -> Iterable[TestDescription]:
+    def query_test_descriptions(self, odata_query: str = "") -> Sequence[TestDescription]:
         """Query test descriptions from the metadata store."""
         query_request = QueryTestDescriptionsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_test_descriptions(query_request)
@@ -192,7 +192,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_test(get_request)
         return Test.from_protobuf(get_response.test)
 
-    def query_tests(self, odata_query: str) -> Iterable[Test]:
+    def query_tests(self, odata_query: str = "") -> Sequence[Test]:
         """Query tests from the metadata store."""
         query_request = QueryTestsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_tests(query_request)
@@ -210,7 +210,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_test_station(get_request)
         return TestStation.from_protobuf(get_response.test_station)
 
-    def query_test_stations(self, odata_query: str) -> Iterable[TestStation]:
+    def query_test_stations(self, odata_query: str = "") -> Sequence[TestStation]:
         """Query test stations from the metadata store."""
         query_request = QueryTestStationsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_test_stations(query_request)
@@ -230,7 +230,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_hardware_item(get_request)
         return HardwareItem.from_protobuf(get_response.hardware_item)
 
-    def query_hardware_items(self, odata_query: str) -> Iterable[HardwareItem]:
+    def query_hardware_items(self, odata_query: str = "") -> Sequence[HardwareItem]:
         """Query hardware items from the metadata store."""
         query_request = QueryHardwareItemsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_hardware_items(query_request)
@@ -251,7 +251,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_software_item(get_request)
         return SoftwareItem.from_protobuf(get_response.software_item)
 
-    def query_software_items(self, odata_query: str) -> Iterable[SoftwareItem]:
+    def query_software_items(self, odata_query: str = "") -> Sequence[SoftwareItem]:
         """Query software items from the metadata store."""
         query_request = QuerySoftwareItemsRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_software_items(query_request)
@@ -272,7 +272,7 @@ class MetadataStoreClient:
         get_response = self._get_metadata_store_client().get_test_adapter(get_request)
         return TestAdapter.from_protobuf(get_response.test_adapter)
 
-    def query_test_adapters(self, odata_query: str) -> Iterable[TestAdapter]:
+    def query_test_adapters(self, odata_query: str = "") -> Sequence[TestAdapter]:
         """Query test adapters from the metadata store."""
         query_request = QueryTestAdaptersRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_test_adapters(query_request)
@@ -308,7 +308,7 @@ class MetadataStoreClient:
         register_response = self._get_metadata_store_client().register_schema(register_request)
         return register_response.schema_id
 
-    def list_schemas(self) -> Iterable[ExtensionSchema]:
+    def list_schemas(self) -> Sequence[ExtensionSchema]:
         """List all schemas in the metadata store."""
         list_request = ListSchemasRequest()
         list_response = self._get_metadata_store_client().list_schemas(list_request)
@@ -364,7 +364,7 @@ class MetadataStoreClient:
         delete_response = self._get_metadata_store_client().delete_alias(delete_request)
         return delete_response.unregistered
 
-    def query_aliases(self, odata_query: str) -> Iterable[Alias]:
+    def query_aliases(self, odata_query: str = "") -> Sequence[Alias]:
         """Query aliases from the metadata store."""
         query_request = QueryAliasesRequest(odata_query=odata_query)
         query_response = self._get_metadata_store_client().query_aliases(query_request)

--- a/src/ni/datastore/metadata/_types/_hardware_item.py
+++ b/src/ni/datastore/metadata/_types/_hardware_item.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -24,9 +24,14 @@ class HardwareItem:
         "asset_identifier",
         "calibration_due_date",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the hardware item."""
+        return self._extensions
 
     def __init__(
         self,
@@ -38,7 +43,7 @@ class HardwareItem:
         asset_identifier: str = "",
         calibration_due_date: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a HardwareItem instance."""
@@ -49,7 +54,9 @@ class HardwareItem:
         self.asset_identifier = asset_identifier
         self.calibration_due_date = calibration_due_date
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_operator.py
+++ b/src/ni/datastore/metadata/_types/_operator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -20,9 +20,14 @@ class Operator:
         "operator_name",
         "role",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the operator."""
+        return self._extensions
 
     def __init__(
         self,
@@ -30,14 +35,16 @@ class Operator:
         operator_name: str = "",
         role: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize an Operator instance."""
         self.operator_name = operator_name
         self.role = role
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_software_item.py
+++ b/src/ni/datastore/metadata/_types/_software_item.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -20,9 +20,14 @@ class SoftwareItem:
         "product",
         "version",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the software item."""
+        return self._extensions
 
     def __init__(
         self,
@@ -30,14 +35,16 @@ class SoftwareItem:
         product: str = "",
         version: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a SoftwareItem instance."""
         self.product = product
         self.version = version
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_test.py
+++ b/src/ni/datastore/metadata/_types/_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -20,9 +20,14 @@ class Test:
         "test_name",
         "description",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the test."""
+        return self._extensions
 
     def __init__(
         self,
@@ -30,14 +35,16 @@ class Test:
         test_name: str = "",
         description: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a Test instance."""
         self.test_name = test_name
         self.description = description
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_test_adapter.py
+++ b/src/ni/datastore/metadata/_types/_test_adapter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -25,9 +25,14 @@ class TestAdapter:
         "asset_identifier",
         "calibration_due_date",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the test adapter."""
+        return self._extensions
 
     def __init__(
         self,
@@ -40,7 +45,7 @@ class TestAdapter:
         asset_identifier: str = "",
         calibration_due_date: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a TestAdapter instance."""
@@ -52,7 +57,9 @@ class TestAdapter:
         self.asset_identifier = asset_identifier
         self.calibration_due_date = calibration_due_date
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_test_description.py
+++ b/src/ni/datastore/metadata/_types/_test_description.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -20,9 +20,14 @@ class TestDescription:
         "uut_id",
         "test_description_name",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the test description."""
+        return self._extensions
 
     def __init__(
         self,
@@ -30,14 +35,16 @@ class TestDescription:
         uut_id: str = "",
         test_description_name: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a TestDescription instance."""
         self.uut_id = uut_id
         self.test_description_name = test_description_name
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_test_station.py
+++ b/src/ni/datastore/metadata/_types/_test_station.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -20,9 +20,14 @@ class TestStation:
         "test_station_name",
         "asset_identifier",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the test station."""
+        return self._extensions
 
     def __init__(
         self,
@@ -30,14 +35,16 @@ class TestStation:
         test_station_name: str = "",
         asset_identifier: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a TestStation instance."""
         self.test_station_name = test_station_name
         self.asset_identifier = asset_identifier
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod

--- a/src/ni/datastore/metadata/_types/_uut.py
+++ b/src/ni/datastore/metadata/_types/_uut.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, MutableMapping
+from typing import Iterable, Mapping, MutableMapping, MutableSequence
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -19,12 +19,22 @@ class Uut:
     __slots__ = (
         "model_name",
         "family",
-        "manufacturers",
+        "_manufacturers",
         "part_number",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def manufacturers(self) -> MutableSequence[str]:
+        """The manufacturers of the UUT."""
+        return self._manufacturers
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the UUT."""
+        return self._extensions
 
     def __init__(
         self,
@@ -34,16 +44,20 @@ class Uut:
         manufacturers: Iterable[str] | None = None,
         part_number: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a Uut instance."""
         self.model_name = model_name
         self.family = family
-        self.manufacturers: Iterable[str] = manufacturers if manufacturers is not None else []
+        self._manufacturers: MutableSequence[str] = (
+            list(manufacturers) if manufacturers is not None else []
+        )
         self.part_number = part_number
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod
@@ -80,7 +94,7 @@ class Uut:
         return (
             self.model_name == other.model_name
             and self.family == other.family
-            and list(self.manufacturers) == list(other.manufacturers)
+            and self.manufacturers == other.manufacturers
             and self.part_number == other.part_number
             and self.link == other.link
             and self.extensions == other.extensions

--- a/src/ni/datastore/metadata/_types/_uut_instance.py
+++ b/src/ni/datastore/metadata/_types/_uut_instance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import MutableMapping
+from typing import Mapping, MutableMapping
 
 from ni.datastore.metadata._grpc_conversion import (
     populate_extension_value_message_map,
@@ -23,9 +23,14 @@ class UutInstance:
         "firmware_version",
         "hardware_version",
         "link",
-        "extensions",
+        "_extensions",
         "schema_id",
     )
+
+    @property
+    def extensions(self) -> MutableMapping[str, str]:
+        """The extensions of the UUT instance."""
+        return self._extensions
 
     def __init__(
         self,
@@ -36,7 +41,7 @@ class UutInstance:
         firmware_version: str = "",
         hardware_version: str = "",
         link: str = "",
-        extensions: MutableMapping[str, str] | None = None,
+        extensions: Mapping[str, str] | None = None,
         schema_id: str = "",
     ) -> None:
         """Initialize a UutInstance instance."""
@@ -46,7 +51,9 @@ class UutInstance:
         self.firmware_version = firmware_version
         self.hardware_version = hardware_version
         self.link = link
-        self.extensions: MutableMapping[str, str] = extensions if extensions is not None else {}
+        self._extensions: MutableMapping[str, str] = (
+            dict(extensions) if extensions is not None else {}
+        )
         self.schema_id = schema_id
 
     @staticmethod


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR entails a number of changes aimed at making collections easier to use and clearer in their function within the Data Store and Metadata Store API.

More specifically, it does the following:

- Strengthens the return type of the various `Query_*` methods (e.g., `Query_Hardware_Items`) to return a `Sequence`, rather than an `Iterable`.
   - This is being done to make the returned result easier to use (with `len()`, indexing, etc.).
   - I also went ahead and gave the `oDataQuery` parameter a default value of empty string, which is what allows the query to return _all_ items of the specified type.
- Strengthen the return type of `Publish_Measurement_Batch` for a similar reason as above
- For the various data types owned by the data store that are exposed through the API (e.g. `TestResult`), the following has been done for the collection properties/fields of each:
    - For fields/properties that are simple lists/collections:
        - The constructor takes an `Iterable` type. This (relatively weak) abstract base class provides flexibility to the calling code that is constructing the instance.
        - The constructor **creates a copy** of this collection and stores it in a `list`.
        - The collection is exposed as a `MutableSequence` read-only property. This allows clients to continue to modify the collection after construction.
   - For fields/properties that are mappings (just `extensions` currently):
       - The constructor takes a `Mapping` type. This (relatively weak) abstract base class provided flexibility to the calling code that is constructing the instance.
       - The constructor **creates a copy** of this collection and stores it in a `dict`. This allows clients to continue to modify the collection after construction.
       - The collection is exposed as a `MutableMapping` read-only property. This allows clients to continue to modify the collection after construction.

Prior to these changes, because we did not create a copy of the collection that was being used to construct an instance of the data type, a scenario like the following was possible:

```
example_software_item_ids = ["id_1", "id_2"]
test_result = TestResult(software_item_ids=example_software_item_ids)

example_software_item_ids.clear()

# test_result.software_item_ids is now empty
```

This is different from how the generated gRPC types function, and taking a step back, my argument is that it is more intuitive that the constructed `TestResult` takes ownership of the list/sequence that it is initialized with. With the set of changes in this PR, the above code snippet would now _not_ result in `TestResult.software_item_ids` being cleared (because of the copy).

### Why should this Pull Request be merged?

This PR improves the API as it relates to its usage of collections.

### What testing has been done?

- Existing tests, notebooks, and examples still pass/function as expected
- Manual testing involving collection properties and `Query_*` method results