### PR TITLE
Add acceptance tests for datastore query methods.

### DIFF
--- a/tests/acceptance/_utils.py
+++ b/tests/acceptance/_utils.py
@@ -9,13 +9,12 @@ from ni.datastore.data import (
 )
 
 
-def create_step(data_store_client: DataStoreClient, description: str) -> str:
+def create_test_result_and_step(data_store_client: DataStoreClient, description: str) -> str:
     """Create a single step within a single test result and return the step_id."""
     test_result_name = f"{description} test result"
     test_result = TestResult(test_result_name=test_result_name)
     test_result_id = data_store_client.create_test_result(test_result)
 
-    # Publish the waveform data
     step = Step(step_name=f"{description} step", test_result_id=test_result_id)
     step_id = data_store_client.create_step(step)
     return step_id

--- a/tests/acceptance/test_query_conditions.py
+++ b/tests/acceptance/test_query_conditions.py
@@ -3,12 +3,12 @@
 from ni.datastore.data import DataStoreClient
 from nitypes.vector import Vector
 
-from tests.acceptance._utils import append_hashed_time, create_step
+from tests.acceptance._utils import append_hashed_time, create_test_result_and_step
 
 
 def test___query_conditions___filter_by_id___single_condition_returned() -> None:
     with DataStoreClient() as data_store_client:
-        step_id = create_step(data_store_client, "query condition filter by id")
+        step_id = create_test_result_and_step(data_store_client, "query condition filter by id")
 
         # Publish a single condition
         condition_name = "query filter by id condition"
@@ -39,7 +39,7 @@ def test___query_conditions___filter_by_id___single_condition_returned() -> None
 
 def test___query_conditions___filter_by_name___correct_conditions_returned() -> None:
     with DataStoreClient() as data_store_client:
-        step_id = create_step(data_store_client, "query condition filter by name")
+        step_id = create_test_result_and_step(data_store_client, "query condition filter by name")
 
         # Publish several similarly named conditions. These names should be unique for each
         # run of this test to prevent previous results from causing the test to fail.

--- a/tests/acceptance/test_query_measurements.py
+++ b/tests/acceptance/test_query_measurements.py
@@ -3,12 +3,12 @@
 from ni.datastore.data import DataStoreClient
 from nitypes.vector import Vector
 
-from tests.acceptance._utils import append_hashed_time, create_step
+from tests.acceptance._utils import append_hashed_time, create_test_result_and_step
 
 
 def test___query_measurements___filter_by_id___single_measurement_returned() -> None:
     with DataStoreClient() as data_store_client:
-        step_id = create_step(data_store_client, "query measurement filter by id")
+        step_id = create_test_result_and_step(data_store_client, "query measurement filter by id")
 
         # Publish a single measurement.
         measurement_name = "query filter by id measurement"
@@ -37,7 +37,7 @@ def test___query_measurements___filter_by_id___single_measurement_returned() -> 
 
 def test___query_measurements___filter_by_name___correct_measurements_returned() -> None:
     with DataStoreClient() as data_store_client:
-        step_id = create_step(data_store_client, "query measurement filter by name")
+        step_id = create_test_result_and_step(data_store_client, "query measurement filter by name")
 
         # Publish several similarly named measurements. These names should be unique for each
         # run of this test to prevent previous results from causing the test to fail.

--- a/tests/acceptance/test_query_steps.py
+++ b/tests/acceptance/test_query_steps.py
@@ -2,20 +2,12 @@
 
 from ni.datastore.data import DataStoreClient, Step, TestResult
 
-from tests.acceptance._utils import append_hashed_time, create_step
+from tests.acceptance._utils import append_hashed_time, create_test_result_and_step
 
 
 def test___query_steps___filter_by_id___single_step_returned() -> None:
     with DataStoreClient() as data_store_client:
-        step_id = create_step(data_store_client, "query steps filter by id")
-
-        # Publish a measurement so that our single step gets published.
-        measurement_name = "query filter by id measurement"
-        data_store_client.publish_measurement(
-            measurement_name=measurement_name,
-            value=123.45,
-            step_id=step_id,
-        )
+        step_id = create_test_result_and_step(data_store_client, "query steps filter by id")
 
         # Query steps based on id.
         queried_steps = data_store_client.query_steps(odata_query=f"$filter=id eq {step_id}")
@@ -39,21 +31,11 @@ def test___query_steps___filter_by_name___correct_steps_returned() -> None:
         for index in range(0, 3):
             step_name = f"{step_name_base} {index}"
             step = Step(step_name=step_name, test_result_id=test_result_id)
-            step_id = data_store_client.create_step(step)
-            data_store_client.publish_measurement(
-                measurement_name="some measurement",
-                value=123,
-                step_id=step_id,
-            )
+            _ = data_store_client.create_step(step)
 
         # Create and publish one more step/measurement that doesn't match the naming pattern.
         step = Step(step_name="some other step name", test_result_id=test_result_id)
-        step_id = data_store_client.create_step(step)
-        data_store_client.publish_measurement(
-            measurement_name="some measurement",
-            value=123,
-            step_id=step_id,
-        )
+        _ = data_store_client.create_step(step)
 
         # Query steps based on name.
         queried_steps = data_store_client.query_steps(


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add acceptance tests for the following methods
- `DataStoreClient.query_measurements`
- `DataStoreClient.query_conditions`
- `DataStoreClient.query_steps`

For each of these methods, I create two tests
- A test that publishes one entity and queries that entity by id
- A test that publishes multiple similarly named entities and queries those entities by name. In this test, an extra entity that doesn't match the naming pattern is also published so we know that we are properly filtering.

Tests for metadata queries will be added in a separate PR.

### Why should this Pull Request be merged?

More progress on implementing [AB#3187182](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3187182)

### What testing has been done?

- All acceptance tests pass against my locally built datastore service.
- Unit tests, mypy, pyright, styleguide
