### PR TITLE
Update hightime deps to 1.0.0

### DIFF
--- a/examples/overview/poetry.lock
+++ b/examples/overview/poetry.lock
@@ -780,7 +780,7 @@ files = []
 develop = true
 
 [package.dependencies]
-hightime = ">=0.3.0.dev0"
+hightime = ">=1.0.0"
 ni-datamonikers-v1-client = ">=0.1.0.dev1"
 ni-measurements-data-v1-client = ">=0.2.0.dev5"
 ni-measurements-metadata-v1-client = ">=0.2.0.dev3"
@@ -1510,4 +1510,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "74ecdc2f8d1bc068300e5fa200d671fc81eeead273b457f5c325a3b499112d83"
+content-hash = "806c4c7a73bb3c4e2bc25b6dbbd6a168cbaadcb081098b9315bdcfd68ef614b0"

--- a/examples/overview/pyproject.toml
+++ b/examples/overview/pyproject.toml
@@ -42,7 +42,7 @@ requires-poetry = '>=2.1,<3.0'
 python = "^3.10"
 protobuf = {version=">=4.21"}
 ni-protobuf-types = { version = ">=1.0.1.dev0", allow-prereleases = true }
-hightime = { version = ">=0.3.0.dev0", allow-prereleases = true }
+hightime = { version = ">=1.0.0" }
 grpcio-tools = [
   { version = "1.49.1", python = ">=3.9,<3.12" },
   { version = "1.59.0", python = ">=3.12,<3.13" },

--- a/examples/system/poetry.lock
+++ b/examples/system/poetry.lock
@@ -501,7 +501,7 @@ files = []
 develop = true
 
 [package.dependencies]
-hightime = ">=0.3.0.dev0"
+hightime = ">=1.0.0"
 ni-datamonikers-v1-client = ">=0.1.0.dev1"
 ni-measurements-data-v1-client = ">=0.2.0.dev5"
 ni-measurements-metadata-v1-client = ">=0.2.0.dev3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3363,13 +3363,6 @@ optional = false
 python-versions = ">=3.8"
 groups = ["dev", "docs", "lint"]
 files = [
-    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
-    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
-    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
-    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
-    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
     {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
@@ -4443,4 +4436,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b38353d58e79281631635dab69294267311b708a8eea134d01c268667ab39286"
+content-hash = "44937dc513beb8e708e1005e3d5c64e4d2aaeb01481bbf67dd5f7a4b8ef992e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ni-datamonikers-v1-client = { version = ">=0.1.0.dev1", allow-prereleases = true
 ni-measurements-data-v1-client = { version = ">=0.2.0.dev5", allow-prereleases = true }
 ni-measurements-metadata-v1-client = { version = ">=0.2.0.dev3", allow-prereleases = true }
 ni-protobuf-types = { version = ">=1.0.1.dev0", allow-prereleases = true }
-hightime = { version = ">=0.3.0.dev0", allow-prereleases = true }
+hightime = { version = ">=1.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates hightime dependencies to a released version of 1.0.0 instead of a dev version.

Fixes #83 

### Why should this Pull Request be merged?

Use released dependencies

### What testing has been done?

Did poetry lock and poetry install on all 3 projects affected by the changes and verified hightime 1.0.0
