### PR TITLE
Bump version in 'main' to 1.1.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.datastore"
-version = "1.0.0"
+version = "1.1.0.dev0"
 license = "MIT"
 description = "APIs for publishing and retrieving data from NI Measurement Data Services"
 authors = [{name = "NI", email = "opensource@ni.com"}]


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps the version in the main branch to 1.1.0.dev0.

### Why should this Pull Request be merged?

To distinguish from the version in releases/1.0 to avoid confusion. In the future this should be done in conjunction with creating a release branch. E.g. if you create releases/1.x, bump main to 1.x+1.0.dev1

### What testing has been done?

PR