### PR TITLE
Update poetry.lock for the examples so they use released versions

### DIFF
--- a/examples/overview/poetry.lock
+++ b/examples/overview/poetry.lock
@@ -188,7 +188,7 @@ version = "1.76.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "grpcio-1.76.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:65a20de41e85648e00305c1bb09a3598f840422e522277641145a32d42dcefcc"},
     {file = "grpcio-1.76.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:40ad3afe81676fd9ec6d9d406eda00933f218038433980aa19d401490e46ecde"},
@@ -544,7 +544,7 @@ version = "1.0.0"
 description = "Hightime Python API"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hightime-1.0.0-py3-none-any.whl", hash = "sha256:ba86d42976c36451b14e11c736e61f296f9f00dbb79c8488e18d70c6b2dbb395"},
     {file = "hightime-1.0.0.tar.gz", hash = "sha256:480d2a03e2c3ed44916d2406d40ab6d10a276ed7f101619fc3fcc1e00c46aacf"},
@@ -740,30 +740,30 @@ files = [
 
 [[package]]
 name = "ni-datamonikers-v1-client"
-version = "0.1.0.dev1"
+version = "1.0.0"
 description = "gRPC Client for NI Data Moniker Service"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_datamonikers_v1_client-0.1.0.dev1-py3-none-any.whl", hash = "sha256:2820039151831aba11e3acd7071a7eaaa9ead2ce28b00f0da7d4b1179fc46150"},
-    {file = "ni_datamonikers_v1_client-0.1.0.dev1.tar.gz", hash = "sha256:dad00b527795517eb0cb786dde7c3989ccac7f9ee5636b1112e9fdd73f4251ae"},
+    {file = "ni_datamonikers_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:e7ce750986c55f415d02ad5690afff0621db86f2e27bdec6b97a59ee18f98c2a"},
+    {file = "ni_datamonikers_v1_client-1.0.0.tar.gz", hash = "sha256:b16eb188b9ac6f3c1693f89191612961484917e2390b0dca07511c6434a25334"},
 ]
 
 [package.dependencies]
-ni-datamonikers-v1-proto = ">=0.1.0.dev0"
-ni-grpc-extensions = ">=0.1.0.dev0"
+ni-datamonikers-v1-proto = ">=1.0.0"
+ni-grpc-extensions = ">=1.1.0"
 
 [[package]]
 name = "ni-datamonikers-v1-proto"
-version = "0.1.0.dev0"
+version = "1.0.0"
 description = "Protobuf data types and service stub for NI data moniker gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_datamonikers_v1_proto-0.1.0.dev0-py3-none-any.whl", hash = "sha256:5ae96df50a010de68b40527e75696eeca2fc1522ab9d8a169a5993f031eb2185"},
-    {file = "ni_datamonikers_v1_proto-0.1.0.dev0.tar.gz", hash = "sha256:cdcf9b4d1fc463f4b2664949f6037bdcc0a6556679eddb3350b5630873da4147"},
+    {file = "ni_datamonikers_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:77d078d810656b3e90152a065047c6203140e0998e8cbdf9d2dbb6e9f477840e"},
+    {file = "ni_datamonikers_v1_proto-1.0.0.tar.gz", hash = "sha256:2e4cf30f9dee343af4a5f328fb785320d2eb30705abc15f0695057177afd5f00"},
 ]
 
 [package.dependencies]
@@ -771,36 +771,34 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-datastore"
-version = "0.1.0.dev7"
+version = "1.0.0"
 description = "APIs for publishing and retrieving data from NI Measurement Data Services"
 optional = false
-python-versions = "^3.10"
-groups = ["dev"]
-files = []
-develop = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "ni_datastore-1.0.0-py3-none-any.whl", hash = "sha256:4471c9f9ae0e3a59b7fb116ccd9e11575b2769c44c44387f932fbad3f6a205e5"},
+    {file = "ni_datastore-1.0.0.tar.gz", hash = "sha256:d4ec36c5664cc10233c21cb80765a539aeaf5c5d14588fb2ff7a01b67bd6df9f"},
+]
 
 [package.dependencies]
 hightime = ">=1.0.0"
-ni-datamonikers-v1-client = ">=0.1.0.dev1"
-ni-measurements-data-v1-client = ">=0.2.0.dev5"
-ni-measurements-metadata-v1-client = ">=0.2.0.dev3"
-ni-protobuf-types = ">=1.0.1.dev0"
+ni-datamonikers-v1-client = ">=1.0.0"
+ni-measurements-data-v1-client = ">=1.0.0"
+ni-measurements-metadata-v1-client = ">=1.0.0"
+ni-protobuf-types = ">=1.1.0"
 protobuf = ">=4.21"
-
-[package.source]
-type = "directory"
-url = "../.."
 
 [[package]]
 name = "ni-grpc-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "gRPC Extensions"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_grpc_extensions-1.0.0-py3-none-any.whl", hash = "sha256:6b8181284370a53546ffd371d334f15e293cae5e9ff06fa2e467d1714bf7a03f"},
-    {file = "ni_grpc_extensions-1.0.0.tar.gz", hash = "sha256:6e066246ce9a4b4420f5e503769b23c31a49c430be6ebd72324c5b5a15c34ebb"},
+    {file = "ni_grpc_extensions-1.1.0-py3-none-any.whl", hash = "sha256:db0357acd244854f4acccf202c89fe6462b4283d264ed639f4e248e6cc86bc9b"},
+    {file = "ni_grpc_extensions-1.1.0.tar.gz", hash = "sha256:028ea33e5c5234bc050bf5dc99f5b61611531de8f012293e9d4c6985b7b37afb"},
 ]
 
 [package.dependencies]
@@ -809,32 +807,32 @@ traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 
 [[package]]
 name = "ni-measurementlink-discovery-v1-client"
-version = "1.1.0.dev0"
+version = "1.1.0"
 description = "gRPC Client for NI Discovery Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurementlink_discovery_v1_client-1.1.0.dev0-py3-none-any.whl", hash = "sha256:2ed52650223f7cf624559515de84a72ea7679a176702c1811462b5273ab9465a"},
-    {file = "ni_measurementlink_discovery_v1_client-1.1.0.dev0.tar.gz", hash = "sha256:d1063173561e1e014c5429ac47c51342dd1f0e1f0d06e46273a8df16cdc13511"},
+    {file = "ni_measurementlink_discovery_v1_client-1.1.0-py3-none-any.whl", hash = "sha256:366dcc3b93627ed1ede488955637e0768b29cb7a375e59ac1020f4c53892d00c"},
+    {file = "ni_measurementlink_discovery_v1_client-1.1.0.tar.gz", hash = "sha256:831b6145cf8def0021cb00579b08a2ad1da5a19fdeedea4522a3cb4a30978c48"},
 ]
 
 [package.dependencies]
 grpcio = ">=1.49.0,<2.0"
-ni-grpc-extensions = ">=0.1.0.dev1"
-ni-measurementlink-discovery-v1-proto = ">=0.1.0.dev1"
+ni-grpc-extensions = ">=1.1.0"
+ni-measurementlink-discovery-v1-proto = ">=1.1.0"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
 
 [[package]]
 name = "ni-measurementlink-discovery-v1-proto"
-version = "1.0.0"
+version = "1.1.0"
 description = "Protobuf data types for NI discovery gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_measurementlink_discovery_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:093eb4ffd27338fbea4909aea30afbd3090f482f3a1dcc98e63bbaf1a6b4da8b"},
-    {file = "ni_measurementlink_discovery_v1_proto-1.0.0.tar.gz", hash = "sha256:11353eefdecc49244783d76a332bc855589eb0bb8c882f53c8f9b0a47ca91115"},
+    {file = "ni_measurementlink_discovery_v1_proto-1.1.0-py3-none-any.whl", hash = "sha256:6a3061ca858d3ee887987dc5130074fc439ce6c2b26fe6b3f9401da023461d43"},
+    {file = "ni_measurementlink_discovery_v1_proto-1.1.0.tar.gz", hash = "sha256:f9a9b4572ac5d169fad21ab56e2639abdb77979cf0dc3a88cdb71b2c783d009c"},
 ]
 
 [package.dependencies]
@@ -842,64 +840,64 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-data-v1-client"
-version = "0.2.0.dev5"
+version = "1.0.0"
 description = "gRPC Client for NI Data Store Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_data_v1_client-0.2.0.dev5-py3-none-any.whl", hash = "sha256:7c9b074df2b17e1d760504883ff219525850e146eed226ece6faa2e250102296"},
-    {file = "ni_measurements_data_v1_client-0.2.0.dev5.tar.gz", hash = "sha256:36be19fa49b38f67796e2cebca6ff82ad3ee9960455bc2a57553d811881d8f7e"},
+    {file = "ni_measurements_data_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:33832370474dc0d6481f1d90623db898f4e051695ae65b66adb14ca8b37d2686"},
+    {file = "ni_measurements_data_v1_client-1.0.0.tar.gz", hash = "sha256:095dc4ece2df8015486ed2bdbbf2dde3dfab02695d5b67eb94c0f0314e5cdb30"},
 ]
 
 [package.dependencies]
-ni-measurementlink-discovery-v1-client = ">=1.1.0.dev0"
-ni-measurements-data-v1-proto = ">=0.1.0.dev7"
+ni-measurementlink-discovery-v1-client = ">=1.1.0"
+ni-measurements-data-v1-proto = ">=1.0.0"
 
 [[package]]
 name = "ni-measurements-data-v1-proto"
-version = "0.1.0.dev7"
+version = "1.0.0"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_data_v1_proto-0.1.0.dev7-py3-none-any.whl", hash = "sha256:3342ad080ce97f28a5df6906d6f427826e2079f5281f20bc2a99a58ca471c40c"},
-    {file = "ni_measurements_data_v1_proto-0.1.0.dev7.tar.gz", hash = "sha256:979b897cd92ea832dc3ad2afbeaa42f005c9161fdf2089bd043ededbf38249ca"},
+    {file = "ni_measurements_data_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:34f2c05b7fd86e3842554a4a31944e381927371a0ff12cf2c5512e37c3eb5dcb"},
+    {file = "ni_measurements_data_v1_proto-1.0.0.tar.gz", hash = "sha256:7c9f58054b5156f65e4ae7bbc0615f58dfcd023a1dabeddbd6a9583bb6fc5df9"},
 ]
 
 [package.dependencies]
-ni-datamonikers-v1-proto = ">=0.1.0.dev0"
-ni-measurements-metadata-v1-proto = ">=0.1.0.dev5"
-ni-protobuf-types = ">=0.1.0.dev3"
+ni-datamonikers-v1-proto = ">=1.0.0"
+ni-measurements-metadata-v1-proto = ">=1.0.0"
+ni-protobuf-types = ">=1.1.0"
 protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-metadata-v1-client"
-version = "0.2.0.dev3"
+version = "1.0.0"
 description = "gRPC Client for NI Metadata Store Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_metadata_v1_client-0.2.0.dev3-py3-none-any.whl", hash = "sha256:df00a33f6da6d2c1c862affe5acaa47a32050c9ffab06a72db4fd86ea89d0671"},
-    {file = "ni_measurements_metadata_v1_client-0.2.0.dev3.tar.gz", hash = "sha256:5865744afa639a0a74fe50493a48493ae4b5a2f79aea60dbde9143cb7f2059fc"},
+    {file = "ni_measurements_metadata_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:c697ce4e98105b810f4da844a598e86e359ff6c90ca7a832e1e23a70327551a7"},
+    {file = "ni_measurements_metadata_v1_client-1.0.0.tar.gz", hash = "sha256:9f9a10810c4c6693239081abbc026414a18df3e3d04daa3cd59010b1eed07f51"},
 ]
 
 [package.dependencies]
-ni-measurementlink-discovery-v1-client = ">=1.1.0.dev0"
-ni-measurements-metadata-v1-proto = ">=0.1.0.dev5"
+ni-measurementlink-discovery-v1-client = ">=1.1.0"
+ni-measurements-metadata-v1-proto = ">=1.0.0"
 
 [[package]]
 name = "ni-measurements-metadata-v1-proto"
-version = "0.1.0.dev5"
+version = "1.0.0"
 description = "Protobuf data types and service stub for NI metadata store gRPC APIs"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_metadata_v1_proto-0.1.0.dev5-py3-none-any.whl", hash = "sha256:b361fa1060d50f8868ef24f944cbab90b5f158a9cee31d5acb76927853f74367"},
-    {file = "ni_measurements_metadata_v1_proto-0.1.0.dev5.tar.gz", hash = "sha256:99dcd79a34d111a545235ab361ffda477b721a29a3697d080743e9b357cc4d21"},
+    {file = "ni_measurements_metadata_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:8844806d6775ac65144100fcd03099aea0c17ed55de696683d0663166f45cee3"},
+    {file = "ni_measurements_metadata_v1_proto-1.0.0.tar.gz", hash = "sha256:3283cf7f0c452812a311b2b9274b5ba1e549f994f6a978a125f1746b85746e6f"},
 ]
 
 [package.dependencies]
@@ -907,18 +905,18 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.0.1.dev0"
+version = "1.1.0"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["main", "dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_protobuf_types-1.0.1.dev0-py3-none-any.whl", hash = "sha256:2e93e62dee45dbf1bb13f812a28a445b4d3953ae3ee9b2c4dce117abf4f2a514"},
-    {file = "ni_protobuf_types-1.0.1.dev0.tar.gz", hash = "sha256:1a84af2eba688747d66bcf8b4e7c333177c4d31caf96537185250b023f2267e9"},
+    {file = "ni_protobuf_types-1.1.0-py3-none-any.whl", hash = "sha256:0c21c096cf8577483dade081c571305fe8d4cc759ce2c780e7437129a375942c"},
+    {file = "ni_protobuf_types-1.1.0.tar.gz", hash = "sha256:98f0583405e219f6e128133c2f6c033f03cd83ebd3ce8098ad74ab99b8a253c1"},
 ]
 
 [package.dependencies]
-nitypes = ">=1.1.0dev0"
+nitypes = ">=1.1.0dev1"
 protobuf = ">=4.21"
 
 [[package]]
@@ -954,14 +952,14 @@ toml = ">=0.10.1"
 
 [[package]]
 name = "nitypes"
-version = "1.1.0.dev0"
+version = "1.1.0.dev1"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
-    {file = "nitypes-1.1.0.dev0-py3-none-any.whl", hash = "sha256:1dd0d15bb741294672ea7d61d98e951c5802eec0130d0162f4f19008dd74c0f6"},
-    {file = "nitypes-1.1.0.dev0.tar.gz", hash = "sha256:a82d2f518f514a24bfb3b9c4e023db23097a786ca40155693610d09578d86f10"},
+    {file = "nitypes-1.1.0.dev1-py3-none-any.whl", hash = "sha256:d98ad6e3f8b92db76b5c1c584431fa27d3e74cce6e20464e43ee0117b02fe089"},
+    {file = "nitypes-1.1.0.dev1.tar.gz", hash = "sha256:50b23e00cc6960996656c4c9ef0ca71dd267fc5c9ca481077b682c29190aa2d3"},
 ]
 
 [package.dependencies]
@@ -978,7 +976,7 @@ version = "2.2.6"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version < \"3.12\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
@@ -1044,7 +1042,7 @@ version = "2.3.5"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version >= \"3.12\""
 files = [
     {file = "numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10"},
@@ -1185,7 +1183,7 @@ version = "4.25.8"
 description = ""
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version <= \"3.12\""
 files = [
     {file = "protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0"},
@@ -1207,7 +1205,7 @@ version = "5.29.5"
 description = ""
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version == \"3.13\""
 files = [
     {file = "protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079"},
@@ -1229,7 +1227,7 @@ version = "6.33.1"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 markers = "python_version >= \"3.14\""
 files = [
     {file = "protobuf-6.33.1-cp310-abi3-win32.whl", hash = "sha256:f8d3fdbc966aaab1d05046d0240dd94d40f2a8c62856d41eaa141ff64a79de6b"},
@@ -1335,7 +1333,7 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
@@ -1464,7 +1462,7 @@ version = "1.0.1"
 description = "Generates Event Tracing for Windows events using TraceLogging"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "traceloggingdynamic-1.0.1-py3-none-any.whl", hash = "sha256:0e19da491a8960725b3622366487ae35f49d8f595bb2e4e5ce1795eb5928db7c"},
@@ -1501,7 +1499,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "lint"]
+groups = ["main", "lint"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1510,4 +1508,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "806c4c7a73bb3c4e2bc25b6dbbd6a168cbaadcb081098b9315bdcfd68ef614b0"
+content-hash = "e2817aa3b427681441b58a1b018dceb0e86924943010d634c9629e81f1d2654d"

--- a/examples/overview/pyproject.toml
+++ b/examples/overview/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overview_example"
-version = "0.1.0.dev0"
+version = "1.0.0"
 license = "MIT"
 description = "Overview of how to use the NI Measurement Data Store APIs for publishing and reading data"
 maintainers = [
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/ni/datastore-python"
 keywords = ["overview", "example"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",
@@ -40,8 +40,9 @@ requires-poetry = '>=2.1,<3.0'
 
 [tool.poetry.dependencies]
 python = "^3.10"
-protobuf = {version=">=4.21"}
-ni-protobuf-types = { version = ">=1.0.1.dev0", allow-prereleases = true }
+ni-datastore = { version=">=1.0.0" }
+protobuf = { version=">=4.21" }
+ni-protobuf-types = { version = ">=1.1.0" }
 hightime = { version = ">=1.0.0" }
 grpcio-tools = [
   { version = "1.49.1", python = ">=3.9,<3.12" },
@@ -53,7 +54,8 @@ grpcio-tools = [
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"
 types-protobuf = ">=4.21"
-ni-datastore = {path = "../..", develop = true}
+# Uncomment to use local ni-datastore code
+# ni-datastore = {path = "../..", develop = true}
 datastore-utilities = { path = "../../utilities", develop = true }
 
 [tool.poetry.group.lint.dependencies]

--- a/examples/system/poetry.lock
+++ b/examples/system/poetry.lock
@@ -188,7 +188,7 @@ version = "1.76.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "grpcio-1.76.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:65a20de41e85648e00305c1bb09a3598f840422e522277641145a32d42dcefcc"},
     {file = "grpcio-1.76.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:40ad3afe81676fd9ec6d9d406eda00933f218038433980aa19d401490e46ecde"},
@@ -265,7 +265,7 @@ version = "1.0.0"
 description = "Hightime Python API"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hightime-1.0.0-py3-none-any.whl", hash = "sha256:ba86d42976c36451b14e11c736e61f296f9f00dbb79c8488e18d70c6b2dbb395"},
     {file = "hightime-1.0.0.tar.gz", hash = "sha256:480d2a03e2c3ed44916d2406d40ab6d10a276ed7f101619fc3fcc1e00c46aacf"},
@@ -461,30 +461,30 @@ files = [
 
 [[package]]
 name = "ni-datamonikers-v1-client"
-version = "0.1.0.dev1"
+version = "1.0.0"
 description = "gRPC Client for NI Data Moniker Service"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_datamonikers_v1_client-0.1.0.dev1-py3-none-any.whl", hash = "sha256:2820039151831aba11e3acd7071a7eaaa9ead2ce28b00f0da7d4b1179fc46150"},
-    {file = "ni_datamonikers_v1_client-0.1.0.dev1.tar.gz", hash = "sha256:dad00b527795517eb0cb786dde7c3989ccac7f9ee5636b1112e9fdd73f4251ae"},
+    {file = "ni_datamonikers_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:e7ce750986c55f415d02ad5690afff0621db86f2e27bdec6b97a59ee18f98c2a"},
+    {file = "ni_datamonikers_v1_client-1.0.0.tar.gz", hash = "sha256:b16eb188b9ac6f3c1693f89191612961484917e2390b0dca07511c6434a25334"},
 ]
 
 [package.dependencies]
-ni-datamonikers-v1-proto = ">=0.1.0.dev0"
-ni-grpc-extensions = ">=0.1.0.dev0"
+ni-datamonikers-v1-proto = ">=1.0.0"
+ni-grpc-extensions = ">=1.1.0"
 
 [[package]]
 name = "ni-datamonikers-v1-proto"
-version = "0.1.0.dev0"
+version = "1.0.0"
 description = "Protobuf data types and service stub for NI data moniker gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_datamonikers_v1_proto-0.1.0.dev0-py3-none-any.whl", hash = "sha256:5ae96df50a010de68b40527e75696eeca2fc1522ab9d8a169a5993f031eb2185"},
-    {file = "ni_datamonikers_v1_proto-0.1.0.dev0.tar.gz", hash = "sha256:cdcf9b4d1fc463f4b2664949f6037bdcc0a6556679eddb3350b5630873da4147"},
+    {file = "ni_datamonikers_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:77d078d810656b3e90152a065047c6203140e0998e8cbdf9d2dbb6e9f477840e"},
+    {file = "ni_datamonikers_v1_proto-1.0.0.tar.gz", hash = "sha256:2e4cf30f9dee343af4a5f328fb785320d2eb30705abc15f0695057177afd5f00"},
 ]
 
 [package.dependencies]
@@ -492,36 +492,34 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-datastore"
-version = "0.1.0.dev7"
+version = "1.0.0"
 description = "APIs for publishing and retrieving data from NI Measurement Data Services"
 optional = false
-python-versions = "^3.10"
-groups = ["dev"]
-files = []
-develop = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "ni_datastore-1.0.0-py3-none-any.whl", hash = "sha256:4471c9f9ae0e3a59b7fb116ccd9e11575b2769c44c44387f932fbad3f6a205e5"},
+    {file = "ni_datastore-1.0.0.tar.gz", hash = "sha256:d4ec36c5664cc10233c21cb80765a539aeaf5c5d14588fb2ff7a01b67bd6df9f"},
+]
 
 [package.dependencies]
 hightime = ">=1.0.0"
-ni-datamonikers-v1-client = ">=0.1.0.dev1"
-ni-measurements-data-v1-client = ">=0.2.0.dev5"
-ni-measurements-metadata-v1-client = ">=0.2.0.dev3"
-ni-protobuf-types = ">=1.0.1.dev0"
+ni-datamonikers-v1-client = ">=1.0.0"
+ni-measurements-data-v1-client = ">=1.0.0"
+ni-measurements-metadata-v1-client = ">=1.0.0"
+ni-protobuf-types = ">=1.1.0"
 protobuf = ">=4.21"
-
-[package.source]
-type = "directory"
-url = "../.."
 
 [[package]]
 name = "ni-grpc-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "gRPC Extensions"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_grpc_extensions-1.0.0-py3-none-any.whl", hash = "sha256:6b8181284370a53546ffd371d334f15e293cae5e9ff06fa2e467d1714bf7a03f"},
-    {file = "ni_grpc_extensions-1.0.0.tar.gz", hash = "sha256:6e066246ce9a4b4420f5e503769b23c31a49c430be6ebd72324c5b5a15c34ebb"},
+    {file = "ni_grpc_extensions-1.1.0-py3-none-any.whl", hash = "sha256:db0357acd244854f4acccf202c89fe6462b4283d264ed639f4e248e6cc86bc9b"},
+    {file = "ni_grpc_extensions-1.1.0.tar.gz", hash = "sha256:028ea33e5c5234bc050bf5dc99f5b61611531de8f012293e9d4c6985b7b37afb"},
 ]
 
 [package.dependencies]
@@ -530,32 +528,32 @@ traceloggingdynamic = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 
 [[package]]
 name = "ni-measurementlink-discovery-v1-client"
-version = "1.1.0.dev0"
+version = "1.1.0"
 description = "gRPC Client for NI Discovery Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurementlink_discovery_v1_client-1.1.0.dev0-py3-none-any.whl", hash = "sha256:2ed52650223f7cf624559515de84a72ea7679a176702c1811462b5273ab9465a"},
-    {file = "ni_measurementlink_discovery_v1_client-1.1.0.dev0.tar.gz", hash = "sha256:d1063173561e1e014c5429ac47c51342dd1f0e1f0d06e46273a8df16cdc13511"},
+    {file = "ni_measurementlink_discovery_v1_client-1.1.0-py3-none-any.whl", hash = "sha256:366dcc3b93627ed1ede488955637e0768b29cb7a375e59ac1020f4c53892d00c"},
+    {file = "ni_measurementlink_discovery_v1_client-1.1.0.tar.gz", hash = "sha256:831b6145cf8def0021cb00579b08a2ad1da5a19fdeedea4522a3cb4a30978c48"},
 ]
 
 [package.dependencies]
 grpcio = ">=1.49.0,<2.0"
-ni-grpc-extensions = ">=0.1.0.dev1"
-ni-measurementlink-discovery-v1-proto = ">=0.1.0.dev1"
+ni-grpc-extensions = ">=1.1.0"
+ni-measurementlink-discovery-v1-proto = ">=1.1.0"
 pywin32 = {version = ">=303", markers = "sys_platform == \"win32\""}
 
 [[package]]
 name = "ni-measurementlink-discovery-v1-proto"
-version = "1.0.0"
+version = "1.1.0"
 description = "Protobuf data types for NI discovery gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_measurementlink_discovery_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:093eb4ffd27338fbea4909aea30afbd3090f482f3a1dcc98e63bbaf1a6b4da8b"},
-    {file = "ni_measurementlink_discovery_v1_proto-1.0.0.tar.gz", hash = "sha256:11353eefdecc49244783d76a332bc855589eb0bb8c882f53c8f9b0a47ca91115"},
+    {file = "ni_measurementlink_discovery_v1_proto-1.1.0-py3-none-any.whl", hash = "sha256:6a3061ca858d3ee887987dc5130074fc439ce6c2b26fe6b3f9401da023461d43"},
+    {file = "ni_measurementlink_discovery_v1_proto-1.1.0.tar.gz", hash = "sha256:f9a9b4572ac5d169fad21ab56e2639abdb77979cf0dc3a88cdb71b2c783d009c"},
 ]
 
 [package.dependencies]
@@ -563,64 +561,64 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-data-v1-client"
-version = "0.2.0.dev5"
+version = "1.0.0"
 description = "gRPC Client for NI Data Store Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_data_v1_client-0.2.0.dev5-py3-none-any.whl", hash = "sha256:7c9b074df2b17e1d760504883ff219525850e146eed226ece6faa2e250102296"},
-    {file = "ni_measurements_data_v1_client-0.2.0.dev5.tar.gz", hash = "sha256:36be19fa49b38f67796e2cebca6ff82ad3ee9960455bc2a57553d811881d8f7e"},
+    {file = "ni_measurements_data_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:33832370474dc0d6481f1d90623db898f4e051695ae65b66adb14ca8b37d2686"},
+    {file = "ni_measurements_data_v1_client-1.0.0.tar.gz", hash = "sha256:095dc4ece2df8015486ed2bdbbf2dde3dfab02695d5b67eb94c0f0314e5cdb30"},
 ]
 
 [package.dependencies]
-ni-measurementlink-discovery-v1-client = ">=1.1.0.dev0"
-ni-measurements-data-v1-proto = ">=0.1.0.dev7"
+ni-measurementlink-discovery-v1-client = ">=1.1.0"
+ni-measurements-data-v1-proto = ">=1.0.0"
 
 [[package]]
 name = "ni-measurements-data-v1-proto"
-version = "0.1.0.dev7"
+version = "1.0.0"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_data_v1_proto-0.1.0.dev7-py3-none-any.whl", hash = "sha256:3342ad080ce97f28a5df6906d6f427826e2079f5281f20bc2a99a58ca471c40c"},
-    {file = "ni_measurements_data_v1_proto-0.1.0.dev7.tar.gz", hash = "sha256:979b897cd92ea832dc3ad2afbeaa42f005c9161fdf2089bd043ededbf38249ca"},
+    {file = "ni_measurements_data_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:34f2c05b7fd86e3842554a4a31944e381927371a0ff12cf2c5512e37c3eb5dcb"},
+    {file = "ni_measurements_data_v1_proto-1.0.0.tar.gz", hash = "sha256:7c9f58054b5156f65e4ae7bbc0615f58dfcd023a1dabeddbd6a9583bb6fc5df9"},
 ]
 
 [package.dependencies]
-ni-datamonikers-v1-proto = ">=0.1.0.dev0"
-ni-measurements-metadata-v1-proto = ">=0.1.0.dev5"
-ni-protobuf-types = ">=0.1.0.dev3"
+ni-datamonikers-v1-proto = ">=1.0.0"
+ni-measurements-metadata-v1-proto = ">=1.0.0"
+ni-protobuf-types = ">=1.1.0"
 protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-metadata-v1-client"
-version = "0.2.0.dev3"
+version = "1.0.0"
 description = "gRPC Client for NI Metadata Store Service"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_metadata_v1_client-0.2.0.dev3-py3-none-any.whl", hash = "sha256:df00a33f6da6d2c1c862affe5acaa47a32050c9ffab06a72db4fd86ea89d0671"},
-    {file = "ni_measurements_metadata_v1_client-0.2.0.dev3.tar.gz", hash = "sha256:5865744afa639a0a74fe50493a48493ae4b5a2f79aea60dbde9143cb7f2059fc"},
+    {file = "ni_measurements_metadata_v1_client-1.0.0-py3-none-any.whl", hash = "sha256:c697ce4e98105b810f4da844a598e86e359ff6c90ca7a832e1e23a70327551a7"},
+    {file = "ni_measurements_metadata_v1_client-1.0.0.tar.gz", hash = "sha256:9f9a10810c4c6693239081abbc026414a18df3e3d04daa3cd59010b1eed07f51"},
 ]
 
 [package.dependencies]
-ni-measurementlink-discovery-v1-client = ">=1.1.0.dev0"
-ni-measurements-metadata-v1-proto = ">=0.1.0.dev5"
+ni-measurementlink-discovery-v1-client = ">=1.1.0"
+ni-measurements-metadata-v1-proto = ">=1.0.0"
 
 [[package]]
 name = "ni-measurements-metadata-v1-proto"
-version = "0.1.0.dev5"
+version = "1.0.0"
 description = "Protobuf data types and service stub for NI metadata store gRPC APIs"
 optional = false
 python-versions = "<4.0,>=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "ni_measurements_metadata_v1_proto-0.1.0.dev5-py3-none-any.whl", hash = "sha256:b361fa1060d50f8868ef24f944cbab90b5f158a9cee31d5acb76927853f74367"},
-    {file = "ni_measurements_metadata_v1_proto-0.1.0.dev5.tar.gz", hash = "sha256:99dcd79a34d111a545235ab361ffda477b721a29a3697d080743e9b357cc4d21"},
+    {file = "ni_measurements_metadata_v1_proto-1.0.0-py3-none-any.whl", hash = "sha256:8844806d6775ac65144100fcd03099aea0c17ed55de696683d0663166f45cee3"},
+    {file = "ni_measurements_metadata_v1_proto-1.0.0.tar.gz", hash = "sha256:3283cf7f0c452812a311b2b9274b5ba1e549f994f6a978a125f1746b85746e6f"},
 ]
 
 [package.dependencies]
@@ -628,18 +626,18 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.0.1.dev0"
+version = "1.1.0"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
-python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
 files = [
-    {file = "ni_protobuf_types-1.0.1.dev0-py3-none-any.whl", hash = "sha256:2e93e62dee45dbf1bb13f812a28a445b4d3953ae3ee9b2c4dce117abf4f2a514"},
-    {file = "ni_protobuf_types-1.0.1.dev0.tar.gz", hash = "sha256:1a84af2eba688747d66bcf8b4e7c333177c4d31caf96537185250b023f2267e9"},
+    {file = "ni_protobuf_types-1.1.0-py3-none-any.whl", hash = "sha256:0c21c096cf8577483dade081c571305fe8d4cc759ce2c780e7437129a375942c"},
+    {file = "ni_protobuf_types-1.1.0.tar.gz", hash = "sha256:98f0583405e219f6e128133c2f6c033f03cd83ebd3ce8098ad74ab99b8a253c1"},
 ]
 
 [package.dependencies]
-nitypes = ">=1.1.0dev0"
+nitypes = ">=1.1.0dev1"
 protobuf = ">=4.21"
 
 [[package]]
@@ -690,14 +688,14 @@ six = "*"
 
 [[package]]
 name = "nitypes"
-version = "1.1.0.dev0"
+version = "1.1.0.dev1"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
-    {file = "nitypes-1.1.0.dev0-py3-none-any.whl", hash = "sha256:1dd0d15bb741294672ea7d61d98e951c5802eec0130d0162f4f19008dd74c0f6"},
-    {file = "nitypes-1.1.0.dev0.tar.gz", hash = "sha256:a82d2f518f514a24bfb3b9c4e023db23097a786ca40155693610d09578d86f10"},
+    {file = "nitypes-1.1.0.dev1-py3-none-any.whl", hash = "sha256:d98ad6e3f8b92db76b5c1c584431fa27d3e74cce6e20464e43ee0117b02fe089"},
+    {file = "nitypes-1.1.0.dev1.tar.gz", hash = "sha256:50b23e00cc6960996656c4c9ef0ca71dd267fc5c9ca481077b682c29190aa2d3"},
 ]
 
 [package.dependencies]
@@ -714,7 +712,7 @@ version = "2.2.6"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 markers = "python_version < \"3.12\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
@@ -780,7 +778,7 @@ version = "2.3.5"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["dev"]
+groups = ["main"]
 markers = "python_version >= \"3.12\""
 files = [
     {file = "numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10"},
@@ -921,7 +919,7 @@ version = "6.33.1"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "protobuf-6.33.1-cp310-abi3-win32.whl", hash = "sha256:f8d3fdbc966aaab1d05046d0240dd94d40f2a8c62856d41eaa141ff64a79de6b"},
     {file = "protobuf-6.33.1-cp310-abi3-win_amd64.whl", hash = "sha256:923aa6d27a92bf44394f6abf7ea0500f38769d4b07f4be41cb52bd8b1123b9ed"},
@@ -1026,7 +1024,7 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
@@ -1167,7 +1165,7 @@ version = "1.0.1"
 description = "Generates Event Tracing for Windows events using TraceLogging"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "traceloggingdynamic-1.0.1-py3-none-any.whl", hash = "sha256:0e19da491a8960725b3622366487ae35f49d8f595bb2e4e5ce1795eb5928db7c"},
@@ -1180,7 +1178,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "lint"]
+groups = ["main", "lint"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1189,4 +1187,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "4de2868f695b4b25eef64b9250425c24082e6ad423e8c566a2bcd7b3cdb931d9"
+content-hash = "d73890f64fdac868ca09c67d4f6d5bddcd1663050ee733fa354369788e19757f"

--- a/examples/system/pyproject.toml
+++ b/examples/system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "system_example"
-version = "0.1.0.dev0"
+version = "1.0.0"
 license = "MIT"
 description = "Example demonstrating how to detect, publish, and query system hardware and software resources"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["system", "example"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",
@@ -42,10 +42,12 @@ requires-poetry = ">=2.1,<3.0"
 include = "src"
 
 [tool.poetry.dependencies]
-nisyscfg = { version = ">=0.2.1", allow-prereleases = true }
+ni-datastore = { version=">=1.0.0" }
+nisyscfg = { version = ">=0.2.1" }
 
 [tool.poetry.group.dev.dependencies]
-ni-datastore = {path = "../..", develop = true}
+# Uncomment to use local ni-datastore code
+# ni-datastore = {path = "../..", develop = true}
 datastore-utilities = { path = "../../utilities", develop = true }
 
 [tool.poetry.group.lint.dependencies]


### PR DESCRIPTION
### What does this Pull Request accomplish?

Re-locks the two examples, which have their own venv, to use released dependencies. Also, comments out the local path dependencies to ni-datastore so when we developers do 'poetry lock', it ensures we don't release the examples with dev dependencies by default.

### Why should this Pull Request be merged?

Otherwise, examples/overview was installing with pre-release dependencies.

### What testing has been done?

Locked and installed locally to watch out for prerelease packages.
