### PR TITLE
Remove links to our internal datastore-service repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 # Measurement Data Services API for Python
 
 `datastore-python` contains Python code for writing to and reading from
-[NI Measurement Data Services](https://github.com/ni/datastore-service).
-It will include examples of how to use the Python API.
+NI Measurement Data Store. It will include examples of how to use the Python API.
 
 # About
 

--- a/examples/overview/README.md
+++ b/examples/overview/README.md
@@ -1,7 +1,7 @@
 # Overview Example
 
 `overview` contains sample Python code for writing to and reading from
-the [NI Measurement Data Store](https://github.com/ni/datastore-service).
+the NI Measurement Data Store.
 
 ## Required Software
 

--- a/examples/system/README.md
+++ b/examples/system/README.md
@@ -2,7 +2,7 @@
 
 `system` contains sample Python code for detecting system hardware
 and software resources and publishing their metadata to the
-[NI Measurement Data Store](https://github.com/ni/datastore-service).
+NI Measurement Data Store.
 
 ## Required Software
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Our README files had a few cases where it was linking to the datastore-service repo which is still internal.

### Why should this Pull Request be merged?

Removing the broken (for external customers) links.

### What testing has been done?

None. Docs changes only.
